### PR TITLE
Scottish and Welsh MMLU fix.

### DIFF
--- a/lm_eval/tasks/mmlu_irish/default/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_irish/default/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: TheRootOf3/mmlu_irish # a copy of `cais/mmlu` with no auxiliary_train split
+dataset_path: TheRootOf3/mmlu_irish # a translated copy of `cais/mmlu` with no auxiliary_train split
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lm_eval/tasks/mmlu_scottish_gaelic/default/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_scottish_gaelic/default/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+dataset_path: TheRootOf3/mmlu_scottish_gaelic # a translated copy of `cais/mmlu` with no auxiliary_train split
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lm_eval/tasks/mmlu_welsh/default/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_welsh/default/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+dataset_path: TheRootOf3/mmlu_welsh # a translated copy of `cais/mmlu` with no auxiliary_train split
 test_split: test
 fewshot_split: dev
 fewshot_config:


### PR DESCRIPTION
This PR fixed a serious bug with Scottish Gaelic and Welsh MMLU tasks. 

Before, when these tasks were executed, the original English MMLU dataset was used with translated prompts.
This PR fixes dataset names.  