### PR TITLE
Added sst2 for brit lags.

### DIFF
--- a/lm_eval/tasks/glue/sst2_britllm/sst2_irish.yaml
+++ b/lm_eval/tasks/glue/sst2_britllm/sst2_irish.yaml
@@ -1,0 +1,13 @@
+group: glue_britllm
+task: sst2_britllm_irish
+dataset_path: britllm/sst2_irish
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: "{{sentence}}\nQuestion: Is this sentence positive or negative?\nAnswer:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive"]
+metric_list:
+  - metric: acc
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/glue/sst2_britllm/sst2_scottish.yaml
+++ b/lm_eval/tasks/glue/sst2_britllm/sst2_scottish.yaml
@@ -1,0 +1,13 @@
+group: glue_britllm
+task: sst2_britllm_scottish
+dataset_path: britllm/sst2_scottish
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: "{{sentence}}\nQuestion: Is this sentence positive or negative?\nAnswer:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive"]
+metric_list:
+  - metric: acc
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/glue/sst2_britllm/sst2_scottish_gaelic.yaml
+++ b/lm_eval/tasks/glue/sst2_britllm/sst2_scottish_gaelic.yaml
@@ -1,0 +1,13 @@
+group: glue_britllm
+task: sst2_britllm_scottish_gaelic
+dataset_path: britllm/sst2_scottish_gaelic
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: "{{sentence}}\nQuestion: Is this sentence positive or negative?\nAnswer:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive"]
+metric_list:
+  - metric: acc
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/glue/sst2_britllm/sst2_welsh.yaml
+++ b/lm_eval/tasks/glue/sst2_britllm/sst2_welsh.yaml
@@ -1,0 +1,13 @@
+group: glue_britllm
+task: sst2_britllm_welsh
+dataset_path: britllm/sst2_welsh
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: "{{sentence}}\nQuestion: Is this sentence positive or negative?\nAnswer:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive"]
+metric_list:
+  - metric: acc
+metadata:
+  version: 1.0


### PR DESCRIPTION
Added translated `glue/sst2` tasks and corresponding hf repos.

To run the entire group of translated sst2, you can use the `glue_britllm` group name.  

**NOTE: I did not translate the prompts this time -- prompts are left in English**
(_"{{sentence}}\nQuestion: Is this sentence positive or negative?\nAnswer:"_)

https://huggingface.co/datasets/britllm/sst2_scottish_gaelic
https://huggingface.co/datasets/britllm/sst2_scottish
https://huggingface.co/datasets/britllm/sst2_welsh
https://huggingface.co/datasets/britllm/sst2_irish

Tested on `microsoft/phi-1_5`:

|             Tasks             |Version|Filter|n-shot|Metric|Value |   |Stderr|
|-------------------------------|-------|------|-----:|------|-----:|---|-----:|
| - sst2_britllm_irish          |      1|none  |     0|acc   |0.5112|±  |0.0171|
| - sst2_britllm_scottish       |      1|none  |     0|acc   |0.7435|±  |0.0150|
| - sst2_britllm_scottish_gaelic|      1|none  |     0|acc   |0.5181|±  |0.0171|
| - sst2_britllm_welsh          |      1|none  |     0|acc   |0.5105|±  |0.0171|

|   Groups   |Version|Filter|n-shot|Metric|Value |   |Stderr|
|------------|-------|------|-----:|------|-----:|---|-----:|
|glue_britllm|N/A    |none  |     0|acc   |0.5706|±  |0.0083|

